### PR TITLE
Graceful Shutdown

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,8 +15,10 @@ import (
 	"expenses-app/pkg/presenters/rest/ui"
 	"expenses-app/pkg/presenters/telegram"
 	"os"
+	"os/signal"
 	"strings"
 	"sync"
+	"syscall"
 
 	_ "github.com/go-sql-driver/mysql"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
@@ -197,9 +199,14 @@ func main() {
 		},
 	})
 	rest.MapRoutes(fiberApp, &healthChecker, &manager, &tracker, &querier, &analyzer)
-	if err := rest.Run(fiberApp, 3535); err != nil {
-		initLogger.Err("Error instanciating mysql: %v", err)
-		return
-	}
-
+	go func() {
+		if err := rest.Run(fiberApp, 3535); err != nil {
+			initLogger.Err("Error instanciating mysql: %v", err)
+			return
+		}
+	}()
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	_ = <-c
+	_ = fiberApp.Shutdown()
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -205,8 +205,9 @@ func main() {
 			return
 		}
 	}()
+	// Shutdown
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-	_ = <-c
+	<-c
 	_ = fiberApp.Shutdown()
 }


### PR DESCRIPTION
### Description  
This PR implements graceful shutdown for the server, ensuring it properly handles termination signals and cleans up resources before exiting. The implementation follows the approach outlined in the Fiber documentation on graceful.  

### Testing  
To verify the implementation, I added a 10-second sleep to the `/api/health/app` endpoint and ran the server. Then, I made a request to the endpoint and pressed `Ctrl + C` in the terminal before the request completed.  

- **With this PR**: The server waited for the request to finish before shutting down.  
- **On the main branch**: The request was closed forcefully when the process was terminated.  

### References  
- [Fiber Documentation: Graceful Shutdown](https://docs.gofiber.io/recipes/graceful-shutdown/)  
- [Graceful Shutdown in Go: Safeguarding Containerized Applications](https://www.codingexplorations.com/blog/graceful-shutdown-in-go-safeguarding-containerized-applications)  
